### PR TITLE
fixed modile menu out of center

### DIFF
--- a/eve/pages/all/MobileMenu.scss
+++ b/eve/pages/all/MobileMenu.scss
@@ -2,7 +2,6 @@
   @media screen and (min-width: 768px) {
     display: none;
   }
-  position: relative;
   .menu-icon {
     svg {
       width: 2.5rem;
@@ -11,8 +10,8 @@
   }
   .nav {
     position: absolute;
-    top: 100%;
-    right: -2.5rem;
+    right: 0;
+    left: 0;
     padding: 2.5rem;
     width: 100vw;
     background-color: #fff;


### PR DESCRIPTION
Fixed the mobile menu 

Before :
![image](https://github.com/evershopcommerce/evetheme/assets/98465646/316dd571-d67d-4cef-a9e5-94181b72422f)

After  :
![image](https://github.com/evershopcommerce/evetheme/assets/98465646/a7bb7b9f-ea2e-4f5d-9b1e-3ba5aba173c8)

What i did : 
 - changed `MobileMenu.scss`